### PR TITLE
Fix default config resolver

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,6 +38,9 @@ class GdbConfigurationProvider implements vscode.DebugConfigurationProvider {
         if (config.request === undefined) {
             config.request = "launch";
         }
+	if (config.preLaunchTask === undefined) {
+	    config.preLaunchTask = "SuperBOL: build (debug)";
+	}
         if (config.target === undefined) {
             config.target = "${file}";
         }


### PR DESCRIPTION
This aligns the code of
`extension.GdbConfigurationProvider.resolveDebugConfiguration` with `extension.GdbConfigurationProvider.provideDebugConfigurations`, so that the debugger can be launched directly in workspaces that lack a `launch.json`.