### PR TITLE
Disable handling of code coverage by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
 							"coverage": {
 								"type": "boolean",
 								"description": "Enable code coverage",
-								"default": true
+								"default": false
 							},
 							"verbose": {
 								"type": "boolean",
@@ -193,7 +193,7 @@
 							"arguments": "",
 							"cwd": "$${_:{workspaceRoot}}",
 							"group": [],
-							"coverage": true,
+							"coverage": false,
 							"verbose": false,
 							"gdbtty": true
 						}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,7 +71,7 @@ class GdbConfigurationProvider implements vscode.DebugConfigurationProvider {
             config.env.LD_LIBRARY_PATH = config.libcobpath + ";" + config.env.LD_LIBRARY_PATH;
         }
         if (config.coverage === undefined) {
-            config.coverage = true;
+            config.coverage = false;
         }
         if (config.gdbtty === undefined) {
             config.gdbtty = true;
@@ -92,7 +92,7 @@ class GdbConfigurationProvider implements vscode.DebugConfigurationProvider {
           arguments: "",
           cwd: "${workspaceFolder}",
           group: [],
-          coverage: true,
+          coverage: false,
           verbose: false,
           gdbtty: true
         };


### PR DESCRIPTION
Rendering of coverage info is now delegated to another extension in SuperBOL.