### PR TITLE
Run tests with old versions of VSCode in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,14 @@ jobs:
            - windows-latest
         node:
            - 20
+        code-version:
+           - stable
+           - 1.66.0
         include:
-           - { os: ubuntu-latest, node: 22 }
-           - { os: ubuntu-latest, node: 24 }
+           - { os: ubuntu-latest, node: 22, code-version: stable }
+           - { os: ubuntu-latest, node: 24, code-version: stable }
     runs-on: ${{ matrix.os }}
-    name: Test with Node ${{ matrix.node }} on ${{ matrix.os }}
+    name: Test with Node ${{ matrix.node }} and VSCode ${{ matrix.code-version }} on ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -33,22 +36,22 @@ jobs:
            node-version: ${{ matrix.node }}
            # node-version-file: 'package.json'
 
-      - name: Cache VSCode test directory
-        uses: actions/cache@v4
-        with:
-           path: .vscode-test
-           key: ${{ runner.os }}-${{ matrix.node }}-vscode-test-${{ hashFiles('package-lock.json') }}
-
       - name: Install dependencies
         run: npm install
 
       - name: Compile
         run: npm run compile
 
+      - name: Cache VSCode test directory
+        uses: actions/cache@v4
+        with:
+           path: .vscode-test
+           key: ${{ runner.os }}-${{ matrix.node }}-${{ matrix.code-version }}-vscode-test-${{ hashFiles('package-lock.json') }}
+
       - name: Run tests
-        run: xvfb-run -a npm test
+        run: xvfb-run -a npm test -- --code-version ${{ matrix.code-version }}
         if: runner.os == 'Linux'
 
       - name: Run tests
-        run: npm test
+        run: npm test -- --code-version ${{ matrix.code-version }}
         if: runner.os != 'Linux'

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 	"license": "GPL-3.0",
 	"icon": "icon.png",
 	"engines": {
-		"vscode": "^1.44.0",
+		"vscode": "^1.66.0",
 		"node": ">=20"
 	},
 	"main": "./out/src/extension",
@@ -261,7 +261,7 @@
 		"prepare": "tsc -p ./",
 		"compile": "tsc -p ./",
 		"watch": "tsc -w -p ./",
-		"test": "npm run compile && npm exec vscode-test",
+		"test": "npm run compile && vscode-test",
 		"lint": "eslint -c .eslintrc.js --ext .ts ./"
 	},
 	"devDependencies": {


### PR DESCRIPTION
The oldest version found that passes the current tests is 1.66.0.